### PR TITLE
Change smallest_power_of_ten to -64 for floats.

### DIFF
--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -398,7 +398,7 @@ inline constexpr int binary_format<double>::smallest_power_of_ten() {
 }
 template <>
 inline constexpr int binary_format<float>::smallest_power_of_ten() {
-  return -65;
+  return -64;
 }
 
 template <> inline constexpr size_t binary_format<double>::max_digits() {


### PR DESCRIPTION
`18446744073709551615e-65` rounds to `0`, and it is the largest possible value with exponent `-65`. Therefore, we can assume the minimal exponent for which we don't round to zero actually is `-64`.